### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Potential fix for [https://github.com/ClementTsang/dircs/security/code-scanning/3](https://github.com/ClementTsang/dircs/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access.  
For this CI workflow, the least-privilege baseline is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI operations without granting write permissions. Place this block near the top-level keys (e.g., after `on:` and before `env:`) so it applies to both `pre-job` and `test` jobs without changing job behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
