### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: ci
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ClementTsang/dircs/security/code-scanning/2](https://github.com/ClementTsang/dircs/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (top-level), so all jobs inherit least-privilege token access unless overridden.  
For this CI workflow, the safest minimal non-breaking baseline is:

- `contents: read` (needed by `actions/checkout` and normal repository reads)

This preserves current functionality while preventing unintended write scopes from inherited defaults.  
Change location: `.github/workflows/ci.yml`, directly after `name: ci` (before `on:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
